### PR TITLE
Prompt for server URL (but provide defaulting)

### DIFF
--- a/ljdump.py
+++ b/ljdump.py
@@ -372,9 +372,11 @@ if __name__ == "__main__":
         from getpass import getpass
         print "ljdump - livejournal archiver"
         print
+        default_server = "http://livejournal.com"
+        server = raw_input("Alternative server to use (e.g. 'https://www.dreamwidth.org'), or hit return for '%s': " % default_server) or default_server
+        print
         print "Enter your Livejournal username and password."
         print
-        server = "http://livejournal.com"
         username = raw_input("Username: ")
         password = getpass("Password: ")
         print


### PR DESCRIPTION
Most people seem to have moved over to Dreamwidth, so I wanted to make it easy to use that server URL, but still provide easy defaulting to LJ for existing users.

No worries if you're not interested, but this was a nice change for my own usage.