### PR TITLE
Add missing Journal field

### DIFF
--- a/ljdump-gui.py
+++ b/ljdump-gui.py
@@ -52,7 +52,7 @@ def do_ok(event = None):
     ok['state'] = DISABLED
     cancel['state'] = DISABLED
     global gWorkerThread
-    gWorkerThread = threading.Thread(None, ljdump.ljdump, args=("http://livejournal.com", username.get(), password.get()))
+    gWorkerThread = threading.Thread(None, ljdump.ljdump, args=("http://livejournal.com", username.get(), password.get(), journal.get()))
     gWorkerThread.start()
     poll()
 
@@ -66,13 +66,16 @@ root.title("ljdump")
 body = Frame(root)
 Label(body, text="Username:").grid(row=0, sticky=W)
 Label(body, text="Password:").grid(row=1, sticky=W)
-Label(body, text="Status:").grid(row=2, sticky=W)
+Label(body, text="Journal:").grid(row=2, sticky=W)
+Label(body, text="Status:").grid(row=3, sticky=W)
 username = Entry(body)
 password = Entry(body, show="*")
+journal = Entry(body)
 status = Label(body, text="Waiting")
 username.grid(row=0, column=1)
 password.grid(row=1, column=1)
-status.grid(row=2, column=1, sticky=W)
+journal.grid(row=2, column=1)
+status.grid(row=3, column=1, sticky=W)
 body.pack(padx=5, pady=5)
 
 box = Frame(root)


### PR DESCRIPTION
The `ljdump` function was expecting 4 arguments, so it was failing. This allows a user to enter the journal argument.