### PR TITLE
Upgrade URLs to HTTPS where possible

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -39,7 +39,7 @@ The configuration settings are:
 This program may be run as often as needed to bring the backup copy up
 to date. Both new and updated items are downloaded.
 
-The community http://ljdump.livejournal.com has been set up for questions
+The community https://ljdump.livejournal.com has been set up for questions
 or comments.
 
 -----

--- a/TODO
+++ b/TODO
@@ -1,6 +1,6 @@
 - userpic without keyword
 - download lj community (usejournal parameter)
-- http://www.livejournal.com/settings/?c=OldEncoding
+- https://www.livejournal.com/settings/?c=OldEncoding
 
 instructions:
-http://jimmyether.livejournal.com/190262.html
+https://jimmyether.livejournal.com/190262.html

--- a/convertdump.py
+++ b/convertdump.py
@@ -191,10 +191,10 @@ def replaceLJTags(entry):
     rv = entry
 
     # replace lj user tags
-    rv = re.sub(userRE, '<a href="http://www.livejournal.com/users/\\1" class="lj-user">\\1</a>', rv) 
+    rv = re.sub(userRE, '<a href="https?://www.livejournal.com/users/\\1" class="lj-user">\\1</a>', rv) 
 
     # replace lj comm tags
-    rv = re.sub(commRE, '<a href="http://community.livejournal.com/\\1/" class="lj-comm">\\1</a>', rv) 
+    rv = re.sub(commRE, '<a href="https?://community.livejournal.com/\\1/" class="lj-comm">\\1</a>', rv) 
 
     # replace lj-cut tags
     rv = re.sub(namedCutRE, '<!--more \\1-->', rv)

--- a/ljdump-gui.py
+++ b/ljdump-gui.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 #
 # ljdump-gui.py - gui interface to ljdump
-# Greg Hewgill <greg@hewgill.com> http://hewgill.com
+# Greg Hewgill <greg@hewgill.com> https://hewgill.com
 #
 # NOTE: This is a work in progress and is probably not suitable for
 #       general release just yet.
@@ -52,7 +52,7 @@ def do_ok(event = None):
     ok['state'] = DISABLED
     cancel['state'] = DISABLED
     global gWorkerThread
-    gWorkerThread = threading.Thread(None, ljdump.ljdump, args=("http://livejournal.com", username.get(), password.get(), journal.get()))
+    gWorkerThread = threading.Thread(None, ljdump.ljdump, args=("https://livejournal.com", username.get(), password.get(), journal.get()))
     gWorkerThread.start()
     poll()
 

--- a/ljdump.config.sample
+++ b/ljdump.config.sample
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <ljdump>
-    <server>http://livejournal.com</server>
+    <server>https://livejournal.com</server>
     <username>myaccount</username>
     <password>mypassword</password>
 </ljdump>

--- a/ljdump.py
+++ b/ljdump.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 #
 # ljdump.py - livejournal archiver
-# Greg Hewgill <greg@hewgill.com> http://hewgill.com
+# Greg Hewgill <greg@hewgill.com> https://hewgill.com/
 # Version 1.5.1
 #
 # LICENSE
@@ -202,7 +202,7 @@ def ljdump(Server, Username, Password, Journal, verbose=True):
             writelast(Journal, lastsync, lastmaxid)
 
     # The following code doesn't work because the server rejects our repeated calls.
-    # http://www.livejournal.com/doc/server/ljp.csp.xml-rpc.getevents.html
+    # https://www.livejournal.com/doc/server/ljp.csp.xml-rpc.getevents.html
     # contains the statement "You should use the syncitems selecttype in
     # conjuntions [sic] with the syncitems protocol mode", but provides
     # no other explanation about how these two function calls should
@@ -380,7 +380,7 @@ if __name__ == "__main__":
         from getpass import getpass
         print "ljdump - livejournal archiver"
         print
-        default_server = "http://livejournal.com"
+        default_server = "https://livejournal.com"
         server = raw_input("Alternative server to use (e.g. 'https://www.dreamwidth.org'), or hit return for '%s': " % default_server) or default_server
         print
         print "Enter your Livejournal username and password."


### PR DESCRIPTION
Livejournal is still emitting http: URLs when rendering pages, so in the convertdump regex I had to make the s optional. :-/