### PR TITLE
Use "clear" auth method rather than "challenge"

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,16 @@
 ChangeLog - ljdump
 
+Unreleased
+
+- Prompt for alternative server, defaulting to LJ
+- Use "clear" auth method, since Dreamwidth has dropped challenge
+  auth; the challenge method is incompatible with secure password
+  handling on the server.
+- Correspondingly, default all URLs to https: to protect passwords
+  in transit.
+- Bugfix: GUI was ignoring "journal" field
+- Add --quiet option to suppress log messages
+
 Version 1.5.1 - 2010-12-29
 
 - Suppress warning about deprecated md5 module

--- a/README.txt
+++ b/README.txt
@@ -27,8 +27,9 @@ The configuration settings are:
   username - The livejournal user name. A subdirectory will be created
              with this same name to store the journal entries.
 
-  password - The account password. This password is never sent in the
-             clear; the livejournal "challenge" password mechanism is used.
+  password - The account password. This password is sent in the clear,
+             so if you specify an alternative server, ensure you use
+             a URL starting with https:// so the connection is encrypted.
 
   journal - Optional: The journal to download entries from. If this is
             not specified, the "username" journal is downloaded. If this


### PR DESCRIPTION
Dreamwidth has dropped challenge auth, since it is incompatible with
secure password handling on the server. (If passwords are hashed in the
database e.g. with bcrypt, the server cannot perform challenge/response
hashing at request time.) Challenge/response has very little other
advantage over clear auth as long as requests are made over TLS, which
should now be the case for all servers.

Details of DW change: https://dw-dev.dreamwidth.org/221167.html

Not sure if this is the direction you want to head; this seemed easier than adding a new flag and config to allow challenge vs. clear auth.